### PR TITLE
Fixed clenup method

### DIFF
--- a/src/Wc.ts
+++ b/src/Wc.ts
@@ -125,10 +125,7 @@ export class Wc extends Component<WcTypeProps> {
       }
 
       if (this.isEventProp(prop, this.props[prop])) {
-        this._element.removeEventListener(
-          prop[2].toLowerCase() + prop.substring(3),
-          this.props[prop]
-        );
+        this._element.removeEventListener(prop, this.props[prop]);
       }
     }
 

--- a/src/Wc.ts
+++ b/src/Wc.ts
@@ -125,7 +125,7 @@ export class Wc extends Component<WcTypeProps> {
       }
 
       if (this.isEventProp(prop, this.props[prop])) {
-        this._element.removeEventListener(prop, this.props[prop]);
+        this.removeEventListener(prop, this.props[prop]);
       }
     }
 

--- a/src/Wc.ts
+++ b/src/Wc.ts
@@ -124,7 +124,7 @@ export class Wc extends Component<WcTypeProps> {
         continue;
       }
 
-      if (this.isEventProp(prop, this.props)) {
+      if (this.isEventProp(prop, this.props[prop])) {
         this._element.removeEventListener(
           prop[2].toLowerCase() + prop.substring(3),
           this.props[prop]


### PR DESCRIPTION
Issue: When a component is destroyed, event listeners still remain in the component and are not removed